### PR TITLE
fix: allow dependabot to trigger Claude workflows

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -37,6 +37,9 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          
+          # Allow dependabot and other bots
+          allowed_bots: "dependabot"
 
           # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4.1)
           # model: "claude-opus-4-1-20250805"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -35,6 +35,9 @@ jobs:
         uses: anthropics/claude-code-action@beta
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          
+          # Allow dependabot and other bots
+          allowed_bots: "dependabot"
 
           # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |


### PR DESCRIPTION
## Summary
- Fix GitHub Actions error when dependabot creates PRs
- Add `allowed_bots: "dependabot"` to Claude workflow configurations

## Problem
Dependabot PRs were failing with error:
```
Error: Prepare step failed with error: Workflow initiated by non-human actor: dependabot (type: Bot). Add bot to allowed_bots list or use '*' to allow all bots.
```

## Solution
Added `allowed_bots: "dependabot"` configuration to:
- `.github/workflows/claude-code-review.yml`
- `.github/workflows/claude.yml`

## Test plan
- [x] Verify workflows have correct configuration
- [ ] Test with actual dependabot PR (will be verified when dependabot creates next PR)

🤖 Generated with [Claude Code](https://claude.ai/code)