### PR TITLE
Fix tar archive error in Release Readiness workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -261,6 +261,7 @@ jobs:
           --exclude='.git' \
           --exclude='*.log' \
           --exclude='*.tmp' \
+          --exclude='nvim-config.tar.gz' \
           .
         echo "✅ Release artifact created: nvim-config.tar.gz"
         


### PR DESCRIPTION
## Summary
- Fixes the "tar: .: file changed as we read it" error in the Release Readiness workflow
- Adds `nvim-config.tar.gz` to the tar exclusion list to prevent the archive from trying to include itself

## Problem
The CI workflow was failing because the tar command was creating `nvim-config.tar.gz` in the current directory while simultaneously trying to archive that same directory, causing a race condition.

## Solution
Explicitly exclude the tar archive file being created from the archive operation.

## Test Plan
- [ ] CI workflow should complete successfully
- [ ] Release artifact should be created without errors
- [ ] All other CI checks should pass