### PR TITLE
Add permissions blocks to all GitHub workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,8 @@ jobs:
   pre-checks:
     name: Pre-flight Checks
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       should_run: ${{ steps.check.outputs.should_run }}
     
@@ -48,6 +50,8 @@ jobs:
   lint-and-validate:
     name: Lint and Validate
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     needs: pre-checks
     if: needs.pre-checks.outputs.should_run == 'true' || github.event_name == 'workflow_dispatch'
     
@@ -93,6 +97,8 @@ jobs:
   test-matrix:
     name: Test on ${{ matrix.os }} (${{ matrix.arch }})
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
     needs: lint-and-validate
     strategy:
       fail-fast: false
@@ -164,6 +170,8 @@ jobs:
   installation-test:
     name: Installation Test on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
     needs: test-matrix
     strategy:
       matrix:
@@ -223,6 +231,9 @@ jobs:
   release-check:
     name: Release Readiness
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: write  # For uploading artifacts
     needs: [test-matrix, installation-test]
     if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop'
     
@@ -281,6 +292,8 @@ jobs:
   summary:
     name: CI Summary
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     needs: [lint-and-validate, test-matrix, installation-test]
     if: always()
     

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,11 @@ env:
   TERM: xterm-256color
   DEBIAN_FRONTEND: noninteractive
 
+permissions:
+  contents: read
+  actions: read
+  checks: read
+
 jobs:
   pre-checks:
     name: Pre-flight Checks

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   shellcheck:
     name: Shell Script Quality

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -13,6 +13,8 @@ jobs:
   shellcheck:
     name: Shell Script Quality
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     
     steps:
     - name: Checkout code
@@ -35,6 +37,8 @@ jobs:
   lua-lint:
     name: Lua Linting
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     
     steps:
     - name: Checkout code

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,9 @@ on:
         required: false
         default: false
 
+permissions:
+  contents: read
+
 jobs:
   test-linux:
     name: Test on Linux

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,8 @@ jobs:
   test-linux:
     name: Test on Linux
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     
     steps:
     - name: Checkout code
@@ -70,6 +72,8 @@ jobs:
   test-macos:
     name: Test on macOS
     runs-on: macos-latest
+    permissions:
+      contents: read
     
     steps:
     - name: Checkout code
@@ -129,6 +133,8 @@ jobs:
   test-cross-platform:
     name: Cross-Platform Validation
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     needs: [test-linux, test-macos]
     
     steps:
@@ -160,6 +166,9 @@ jobs:
   coverage:
     name: Test Coverage Report
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: write  # For uploading test results
     needs: [test-linux, test-macos]
     if: always()  # Run even if tests fail to get coverage report
     


### PR DESCRIPTION
## Summary
Adds explicit permissions blocks to all GitHub workflows and individual jobs that were missing them, following GitHub security best practices with maximum granularity.

## Changes Made

### Workflow-Level Permissions
- **ci.yml**: Added `contents: read`, `actions: read`, `checks: read` permissions for comprehensive CI operations
- **test.yml**: Added `contents: read` permission for basic testing workflow
- **quality.yml**: Added `contents: read` permission for code quality checks

### Job-Level Permissions (Enhanced Security)
- **All checkout jobs**: `contents: read` for code access
- **ci.yml release-check job**: `contents: read`, `actions: write` for artifact uploads
- **test.yml coverage job**: `contents: read`, `actions: write` for test result uploads
- **All other jobs**: `contents: read` only (minimum required)

## Already Secured
- ✅ **claude.yml**: Already has appropriate permissions
- ✅ **claude-code-review.yml**: Already has appropriate permissions  
- ✅ **pr-validation.yml**: Already has appropriate permissions

## Security Benefits
- **Principle of Least Privilege**: Each workflow and job only gets the minimum permissions needed
- **Job Isolation**: Individual jobs have isolated permission scopes
- **Attack Surface Reduction**: Limits potential damage from compromised workflow tokens
- **Compliance**: Follows GitHub's security recommendations for Actions
- **Granular Control**: Maximum security with job-level permission boundaries

## Permissions Rationale
- `contents: read` - Required for all workflows/jobs to checkout code
- `actions: read` - Needed by CI workflow for reading workflow run results  
- `checks: read` - Needed by CI workflow for comprehensive status reporting
- `actions: write` - Only for jobs that upload artifacts (release-check, coverage)

## Test Plan
- [ ] All workflows should continue to function normally
- [ ] No additional permissions requested beyond what's needed
- [ ] CI pipeline completes successfully
- [ ] Artifact uploads work correctly for release-check and coverage jobs